### PR TITLE
cancel sink to break retain cycle

### DIFF
--- a/Sources/Popover+Context.swift
+++ b/Sources/Popover+Context.swift
@@ -97,6 +97,10 @@ public extension Popover {
                 }
             }
         }
+        
+        deinit {
+            changeSink?.cancel()
+        }
     }
 }
 #endif


### PR DESCRIPTION
cancel the sink to break the retain cycle that was causing the memory leak