### PR TITLE
fix popover memory leak

### DIFF
--- a/Sources/PopoverModel.swift
+++ b/Sources/PopoverModel.swift
@@ -61,7 +61,19 @@ class PopoverModel: ObservableObject {
 
     /// Removes a `Popover` from this model.
     func remove(_ popover: Popover) {
-        popovers.removeAll { $0 == popover }
+        guard let index = popovers.firstIndex(where: { $0 == popover }) else { return }
+
+        // Step 1: Replace the actual popover with an empty popover (with clean context/view/background)
+        let emptyPopover = Popover(
+            attributes: .init(),
+            view: { EmptyView() },
+            background: { EmptyView() }
+        )
+
+        popovers[index] = emptyPopover
+
+        // Now remove the empty
+        popovers.remove(at: index)
     }
 
     /**


### PR DESCRIPTION
Overwrite the popover with an empty one before deleting it, making sure the View is released when the popover is dismissed